### PR TITLE
Alternative BW strategy & minors -> master

### DIFF
--- a/main-module/src/main/resources/application.conf
+++ b/main-module/src/main/resources/application.conf
@@ -28,6 +28,6 @@ logging {
         debug = false
     },
     strategy {
-        debug = false
+        debug = true
     }
 }

--- a/main-module/src/main/resources/application.conf
+++ b/main-module/src/main/resources/application.conf
@@ -9,9 +9,14 @@ tasks = [
 ]
 
 wait-for-task-delay = 1.seconds
-bw-threshold = 0.9
-bw-retry-delay = 1.seconds
-mmbwmon-attempts = 5
+
+mmbwmon {
+    wait-before-measurement = 250.millis
+    attempts = 5
+    retry-delay = 500.millis
+    threshold = 0.9
+}
+
 task-speed {
     measurement = 250.millis
     wait-before-measurement = 100.millis

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/Configuration.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/Configuration.scala
@@ -1,7 +1,7 @@
 package ru.skelantros.coscheduler.main
 
 import ru.skelantros.coscheduler.logging.Logger
-import ru.skelantros.coscheduler.main.Configuration.LoggingOptions
+import ru.skelantros.coscheduler.main.Configuration.{LoggingOptions, MmbwmonOptions, SpeedTest}
 import ru.skelantros.coscheduler.main.strategy.Strategy.StrategyTask
 import ru.skelantros.coscheduler.model.Node
 import sttp.client3.UriContext
@@ -14,11 +14,10 @@ case class Configuration(
     nodesUri: Vector[Uri],
     tasks: Vector[StrategyTask],
     waitForTaskDelay: Duration,
-    bwThreshold: Option[Double],
-    bwRetryDelay: Option[Duration],
-    mmbwmonAttempts: Option[Int],
     taskSpeed: Option[Configuration.TaskSpeed],
-    logging: Option[LoggingOptions]
+    logging: Option[LoggingOptions],
+    speedTest: Option[SpeedTest],
+    mmbwmon: Option[MmbwmonOptions]
 ) {
     val schedulingSystemLogging: Logger.Config =
         logging.flatMap(_.schedulingSystem).getOrElse(Logger.defaultConfig)
@@ -36,4 +35,8 @@ object Configuration {
          schedulingSystem: Option[Logger.Config],
          strategy: Option[Logger.Config]
     )
+
+    case class MmbwmonOptions(waitBeforeMeasurement: Option[FiniteDuration], attempts: Option[Int], retryDelay: Option[FiniteDuration], threshold: Option[Double])
+
+    case class SpeedTest(tasks: Vector[StrategyTask], params: TaskSpeed, nodeUri: Uri)
 }

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/app/AbstractMainApp.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/app/AbstractMainApp.scala
@@ -1,17 +1,12 @@
 package ru.skelantros.coscheduler.main.app
 
 import cats.effect.{ExitCode, IO, IOApp}
-import pureconfig.ConfigSource
-import pureconfig.generic.auto._
 import ru.skelantros.coscheduler.main.Configuration
 import ru.skelantros.coscheduler.main.strategy.Strategy
 import ru.skelantros.coscheduler.main.system.SchedulingSystem
 
-trait AbstractMainApp[S <: SchedulingSystem] extends IOApp {
+trait AbstractMainApp[S <: SchedulingSystem] extends IOApp with WithConfigLoad {
     val initStrategy: (S, Configuration) => Strategy
-
-    private def loadConfiguration(args: List[String]): Option[Configuration] =
-        args.headOption.fold(ConfigSource.default)(ConfigSource.file).load[Configuration].toOption
 
     def schedulingSystem(config: Configuration): S
 

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/app/MemoryBWAltStrategyApp.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/app/MemoryBWAltStrategyApp.scala
@@ -1,0 +1,13 @@
+package ru.skelantros.coscheduler.main.app
+
+import ru.skelantros.coscheduler.main.Configuration
+import ru.skelantros.coscheduler.main.strategy.{MemoryBWAltStrategy, Strategy}
+import ru.skelantros.coscheduler.main.system.{HttpSchedulingSystem, SchedulingSystem, WithRamBenchmark}
+
+object MemoryBWAltStrategyApp extends AbstractMainApp[SchedulingSystem with WithRamBenchmark] {
+    override val initStrategy: (SchedulingSystem with WithRamBenchmark, Configuration) => Strategy =
+        MemoryBWAltStrategy(_, _)
+
+    override def schedulingSystem(config: Configuration): SchedulingSystem with WithRamBenchmark =
+        HttpSchedulingSystem.withLogging(config)
+}

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/app/MemoryBWAltStrategyApp.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/app/MemoryBWAltStrategyApp.scala
@@ -2,12 +2,12 @@ package ru.skelantros.coscheduler.main.app
 
 import ru.skelantros.coscheduler.main.Configuration
 import ru.skelantros.coscheduler.main.strategy.{MemoryBWAltStrategy, Strategy}
-import ru.skelantros.coscheduler.main.system.{HttpSchedulingSystem, SchedulingSystem, WithRamBenchmark}
+import ru.skelantros.coscheduler.main.system.{HttpSchedulingSystem, SchedulingSystem, WithMmbwmon}
 
-object MemoryBWAltStrategyApp extends AbstractMainApp[SchedulingSystem with WithRamBenchmark] {
-    override val initStrategy: (SchedulingSystem with WithRamBenchmark, Configuration) => Strategy =
+object MemoryBWAltStrategyApp extends AbstractMainApp[SchedulingSystem with WithMmbwmon] {
+    override val initStrategy: (SchedulingSystem with WithMmbwmon, Configuration) => Strategy =
         MemoryBWAltStrategy(_, _)
 
-    override def schedulingSystem(config: Configuration): SchedulingSystem with WithRamBenchmark =
+    override def schedulingSystem(config: Configuration): SchedulingSystem with WithMmbwmon =
         HttpSchedulingSystem.withLogging(config)
 }

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/app/MemoryBWMainApp.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/app/MemoryBWMainApp.scala
@@ -2,11 +2,11 @@ package ru.skelantros.coscheduler.main.app
 
 import ru.skelantros.coscheduler.main.Configuration
 import ru.skelantros.coscheduler.main.strategy.{MemoryBWStrategy, Strategy}
-import ru.skelantros.coscheduler.main.system.{HttpSchedulingSystem, SchedulingSystem, WithRamBenchmark}
+import ru.skelantros.coscheduler.main.system.{HttpSchedulingSystem, SchedulingSystem, WithMmbwmon}
 
-object MemoryBWMainApp extends AbstractMainApp[SchedulingSystem with WithRamBenchmark] {
-    override val initStrategy: (SchedulingSystem with WithRamBenchmark, Configuration) => Strategy = MemoryBWStrategy(_, _)
+object MemoryBWMainApp extends AbstractMainApp[SchedulingSystem with WithMmbwmon] {
+    override val initStrategy: (SchedulingSystem with WithMmbwmon, Configuration) => Strategy = MemoryBWStrategy(_, _)
 
-    override def schedulingSystem(config: Configuration): SchedulingSystem with WithRamBenchmark =
+    override def schedulingSystem(config: Configuration): SchedulingSystem with WithMmbwmon =
         HttpSchedulingSystem.withLogging(config)
 }

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/app/SpeedTestApp.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/app/SpeedTestApp.scala
@@ -1,0 +1,42 @@
+package ru.skelantros.coscheduler.main.app
+
+import cats.effect.{ExitCode, IO, IOApp}
+import ru.skelantros.coscheduler.logging.{DefaultLogger, Logger}
+import ru.skelantros.coscheduler.main.Configuration
+import ru.skelantros.coscheduler.main.implicits.ParMapOps
+import ru.skelantros.coscheduler.main.system.{EndpointException, HttpSchedulingSystem}
+import ru.skelantros.coscheduler.model.Task
+
+object SpeedTestApp extends IOApp with WithConfigLoad with DefaultLogger {
+    override def loggerConfig: Logger.Config = Logger.defaultConfig
+
+    private def measureLoop(params: Configuration.TaskSpeed, system: HttpSchedulingSystem)(task: Task.Created): IO[Unit] =
+        system.speedOf(params.measurement.get)(task).flatMap(m =>
+            log.info(task.title)(m) >> IO.sleep(params.waitBeforeMeasurement.get) >> measureLoop(params, system)(task)
+        ).recoverWith {
+            case EndpointException(t) => log.info(task.title)(s"Measurement completed with: $t") >> IO.unit
+        }
+
+    private def app(configuration: Configuration, speedTest: Configuration.SpeedTest): IO[Unit] = {
+        val system = new HttpSchedulingSystem(configuration)
+
+        for {
+            node <- system.nodeInfo(speedTest.nodeUri)
+            tasksStarted <- speedTest.tasks.parMap(
+                system.buildTaskFromTuple(node)(_).flatMap(
+                    system.createTask(_, None)
+                ).flatMap(
+                    system.startTask
+                )
+            )
+            action <- tasksStarted.parMap(measureLoop(speedTest.params, system)) >> IO.unit
+        } yield action
+    }
+
+    override def run(args: List[String]): IO[ExitCode] = {
+        val cfg = loadConfiguration(args).get
+        val speedTest = cfg.speedTest.get
+
+        app(cfg, speedTest) >> IO.pure(ExitCode.Success)
+    }
+}

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/app/WithConfigLoad.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/app/WithConfigLoad.scala
@@ -1,0 +1,10 @@
+package ru.skelantros.coscheduler.main.app
+
+import pureconfig.ConfigSource
+import ru.skelantros.coscheduler.main.Configuration
+import pureconfig.generic.auto._
+
+trait WithConfigLoad {
+    protected def loadConfiguration(args: List[String]): Option[Configuration] =
+        args.headOption.fold(ConfigSource.default)(ConfigSource.file).load[Configuration].toOption
+}

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/implicits.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/implicits.scala
@@ -1,8 +1,11 @@
 package ru.skelantros.coscheduler.main
 
-import cats.{Traverse, UnorderedTraverse}
+import cats.{Monad, Traverse, UnorderedTraverse}
 import cats.effect.IO
+import cats.effect.kernel.Clock
 import cats.implicits._
+
+import scala.concurrent.duration.FiniteDuration
 
 object implicits {
     implicit class ParMapOps[A, CC[_] : Traverse](collection: CC[A]) {
@@ -11,5 +14,13 @@ object implicits {
 
     implicit class GenMapOps[A, CC[_] : UnorderedTraverse](collection: CC[A]) {
         def genParMap[B, CC1[_] : Traverse](convert: CC[A] => CC1[A])(f: A => IO[B]): IO[CC1[B]] = convert(collection).parMap(f)
+    }
+
+    implicit class TimeMeasureOps[F[_]: Clock: Monad, A](action: F[A]) {
+        def withTime: F[(A, FiniteDuration)] = for {
+            start <- Clock[F].monotonic
+            result <- action
+            end <- Clock[F].monotonic
+        } yield (result, end - start)
     }
 }

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/strategy/MemoryBWAltStrategy.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/strategy/MemoryBWAltStrategy.scala
@@ -1,0 +1,126 @@
+package ru.skelantros.coscheduler.main.strategy
+
+import cats.effect.{IO, Ref}
+import cats.implicits._
+import ru.skelantros.coscheduler.main.Configuration
+import ru.skelantros.coscheduler.main.implicits._
+import ru.skelantros.coscheduler.main.strategy.MemoryBWAltStrategy._
+import ru.skelantros.coscheduler.main.strategy.Strategy._
+import ru.skelantros.coscheduler.main.system.{SchedulingSystem, WithRamBenchmark}
+import ru.skelantros.coscheduler.main.utils.SemaphoreResource
+import ru.skelantros.coscheduler.model.{CpuSet, Node, Task}
+
+import scala.collection.immutable.TreeSet
+import scala.concurrent.duration.DurationInt
+
+class MemoryBWAltStrategy(val schedulingSystem: SchedulingSystem with WithRamBenchmark, val config: Configuration) extends Strategy {
+    private val waitBeforeMmbwmon = config.mmbwmon.flatMap(_.waitBeforeMeasurement).getOrElse(250.millis)
+    private val mmbwmonAttempts = config.mmbwmon.flatMap(_.attempts).getOrElse(5)
+    private val threshold = config.mmbwmon.flatMap(_.threshold).getOrElse(0.9)
+    private val delay = config.mmbwmon.flatMap(_.retryDelay).getOrElse(500.millis)
+
+    override def execute(nodes: Vector[Node], tasks: Vector[StrategyTask]): IO[Unit] = for {
+        sharedTasksRef <- Ref.of[IO, SharedTasks](tasks.toSet)
+        nodesWithBwResults <- nodes.map(benchmarkAllTasks(tasks)).parSequence
+        workerNodes <- nodesWithBwResults.parMap((WorkerNode(sharedTasksRef) _).tupled)
+        tasksToWait <- workerNodes.parMap(_.execute)
+        action <- tasksToWait.flatten.parMap(schedulingSystem.waitForTask) >> IO.unit
+    } yield action
+
+    private def benchmarkAllTasks(tasks: Vector[StrategyTask])(node: Node): IO[(Node, Vector[NodeTask])] = for {
+        createdTasks <- tasks.parMap { sTask =>
+            (
+                schedulingSystem.buildTaskFromTuple(node)(sTask)
+                .flatMap(schedulingSystem.createTask(_, Some(CpuSet(1, node.cores - 1)))),
+                sTask.pure[IO]
+            ).tupled
+        }
+        nodeTasks <- createdTasks.map((benchmarkTask(node) _).tupled).sequence
+    } yield (node, nodeTasks)
+
+    private def benchmarkTask(node: Node)(createdTask: Task.Created, sTask: StrategyTask): IO[NodeTask] = for {
+        startedTask <- schedulingSystem.startTask(createdTask)
+        benchmarkResult <- schedulingSystem.avgRamBenchmark(node)(mmbwmonAttempts).delayBy(waitBeforeMmbwmon)
+        pausedTask <- schedulingSystem.savePauseTask(startedTask)
+    } yield NodeTask(sTask, benchmarkResult, pausedTask)
+
+    private class WorkerNode(node: Node, nodeTasks: TreeSet[NodeTask], sharedTasks: Ref[IO, SharedTasks], bwAndWaiting: SemaphoreResource[(Ref[IO, Double], Ref[IO, Boolean]), IO]) {
+        def execute: IO[Set[Task.Created]] = go(nodeTasks, Set.empty)
+
+        private def go(nodeTasks: TreeSet[NodeTask], tasks: Set[Task.Created]): IO[Set[Task.Created]] = for {
+            findTaskRes <- findTask(nodeTasks)
+            action <- findTaskRes match {
+                case TaskFound(task) =>
+                    schedulingSystem.saveResumeTask(task.task) >> runTaskCallback(task).start >> go(nodeTasks - task, tasks + task.task)
+                case NoMoreTasks => tasks.pure[IO]
+                case NotFound => go(nodeTasks, tasks).delayBy(delay)
+            }
+        } yield action
+
+        private def findTask(nodeTasks: TreeSet[NodeTask]): IO[FindTaskResult] = bwAndWaiting.getAndComputeF { case (bwRef, waitingRef) =>
+            for {
+                bw <- bwRef.get
+                waiting <- waitingRef.get
+                result <-
+                    if (waiting) NotFound.pure[IO]
+                    else sharedTasks.modify { sts =>
+                        if (sts.isEmpty) (sts, IO.pure(NoMoreTasks))
+                        else nodeTasks.find(nt => sts(nt.sTask)) match {
+                            case Some(nodeTask) if bw == 0 || bw + nodeTask.speed <= threshold =>
+                                (sts - nodeTask.sTask, IO.pure(TaskFound(nodeTask)))
+                            case _ =>
+                                (sts, IO.pure(NotFound) <* waitingRef.set(true))
+                        }
+                    }.flatten
+            } yield result
+        }
+
+        private def runTaskCallback(task: NodeTask): IO[Unit] = {
+            val callbackStart = bwAndWaiting.getAndComputeF { case (bwRef, _) =>
+                for {
+                    _ <- bwRef.update(_ + task.speed)
+                    totalBw <- bwRef.get
+                    _ <- log.debug(node.id)(s"Task $task has been started. totalBw = $totalBw")
+                } yield ()
+            }
+
+            val callbackEnd = bwAndWaiting.getAndComputeF { case (bwRef, waitingRef) =>
+                for {
+                    _ <- bwRef.update(_ - task.speed)
+                    _ <- waitingRef.set(false)
+                    totalBw <- bwRef.get
+                    _ <- log.debug(node.id)(s"Task $task has been completed. totalBw = $totalBw")
+                } yield ()
+            }
+
+            callbackStart >> schedulingSystem.waitForTask(task.task) >> callbackEnd
+        }
+    }
+
+    private object WorkerNode {
+        def apply(sharedTasks: Ref[IO, SharedTasks])(node: Node, nodeTasks: Iterable[NodeTask]): IO[WorkerNode] = for {
+            bwRef <- Ref.of[IO, Double](0d)
+            waitingRef <- Ref.of[IO, Boolean](false)
+            resource <- SemaphoreResource[IO].from((bwRef, waitingRef), 1)
+        } yield new WorkerNode(node, NodeTask.setFrom(nodeTasks), sharedTasks, resource)
+    }
+}
+
+object MemoryBWAltStrategy {
+    def apply(schedulingSystem: SchedulingSystem with WithRamBenchmark, config: Configuration): MemoryBWAltStrategy =
+        new MemoryBWAltStrategy(schedulingSystem, config)
+
+    private type SharedTasks = Set[StrategyTask]
+}
+
+private sealed trait FindTaskResult
+private case class TaskFound(task: NodeTask) extends FindTaskResult
+private case object NoMoreTasks extends FindTaskResult
+private case object NotFound extends FindTaskResult
+
+private case class NodeTask(sTask: StrategyTask, speed: Double, task: Task.Created)
+
+private object NodeTask {
+    private val ordering = Ordering.by[NodeTask, Double](_.speed).reverse
+    def setFrom(coll: Iterable[NodeTask]): TreeSet[NodeTask] = TreeSet.from(coll)(ordering)
+}

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/strategy/MemoryBWAltStrategy.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/strategy/MemoryBWAltStrategy.scala
@@ -42,6 +42,7 @@ class MemoryBWAltStrategy(val schedulingSystem: SchedulingSystem with WithMmbwmo
         startedTask <- schedulingSystem.startTask(createdTask)
         benchmarkResult <- schedulingSystem.avgMmbwmon(node)(mmbwmonAttempts).delayBy(waitBeforeMmbwmon)
         pausedTask <- schedulingSystem.savePauseTask(startedTask)
+        _ <- log.debug(node.id)(s"${createdTask.title}: $benchmarkResult")
     } yield NodeTask(sTask, benchmarkResult, pausedTask)
 
     private class WorkerNode(node: Node, nodeTasks: TreeSet[NodeTask], sharedTasks: Ref[IO, SharedTasks], bwAndWaiting: SemaphoreResource[(Ref[IO, Double], Ref[IO, Boolean]), IO]) {

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/strategy/MemoryBWStrategy.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/strategy/MemoryBWStrategy.scala
@@ -142,6 +142,9 @@ class MemoryBWStrategy(val schedulingSystem: SchedulingSystem with WithRamBenchm
         } yield action
     }
 
+    val x: Set[Int] = ???
+    x.
+
     override def execute(nodes: Vector[Node], tasks: Vector[(TaskName, File)]): IO[Unit] = for {
         tasksRef <- Ref.of[IO, Set[StrategyTaskInfo]](tasks.map(StrategyTaskInfo(_)).toSet)
         tasksToWait <- nodes.map(NodeWorker(tasksRef)).map(_.start).parSequence

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/strategy/SequentialStrategy.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/strategy/SequentialStrategy.scala
@@ -26,7 +26,7 @@ class SequentialStrategy(val schedulingSystem: SchedulingSystem, val config: Con
                     schedulingSystem.buildTaskFromTuple(node)(task)
                         .flatMap(schedulingSystem.createTask(_))
                         .flatMap(schedulingSystem.startTask)
-                        .flatMap(schedulingSystem.waitForTask) >> execute
+                        .flatMap(schedulingSystem.waitForTask) >> log.debug(node.id)(s"$task executed.") >> execute
                 case None => IO.unit
             }
         } yield action

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/strategy/Strategy.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/strategy/Strategy.scala
@@ -30,8 +30,9 @@ trait Strategy extends DefaultLogger {
         nodes <- config.nodesUri.parMap(schedulingSystem.nodeInfo)
         _ <- nodes.parMap(schedulingSystem.initSession(sc))
         _ <- log.info("")(s"SessionID = ${sc.sessionId}. Starting strategy execution...")
-        action <- execute(nodes, tasks)
-    } yield action
+        actionWithTime <- execute(nodes, tasks).withTime
+        _ <- log.info("")(s"Strategy execution has been completed. Total time is ${actionWithTime._2}")
+    } yield actionWithTime._1
 }
 
 object Strategy {

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/system/HttpSchedulingSystem.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/system/HttpSchedulingSystem.scala
@@ -1,7 +1,6 @@
 package ru.skelantros.coscheduler.main.system
 import cats.effect.IO
 import ru.skelantros.coscheduler.model.{CpuSet, Node, SessionContext, Task}
-import ru.skelantros.coscheduler.main.system.SchedulingSystem.TaskLogs
 import ru.skelantros.coscheduler.image.ImageArchive
 import ru.skelantros.coscheduler.logging.Logger
 import ru.skelantros.coscheduler.main.Configuration
@@ -16,7 +15,7 @@ import scala.concurrent.duration.FiniteDuration
 
 class HttpSchedulingSystem(val config: Configuration)
     extends SchedulingSystem
-    with WithRamBenchmark
+    with WithMmbwmon
     with WithTaskSpeedEstimate {
 
     private val client = Http4sBackend.usingDefaultEmberClientBuilder[IO]()
@@ -73,7 +72,7 @@ class HttpSchedulingSystem(val config: Configuration)
         makeRequest(task.node.uri, WorkerEndpoints.isRunning)(task)
 
     // 1 - (measured - 0.33) / (1 - 0.33) = 1 + 0.33/0.67 - measured/0.67 = 1 / 0.67 - measured / 0.67 ~=~ 3/2 - 3/2 * measured = 3/2 (1 - measured)
-    override def ramBenchmark(node: Node): IO[Double] = for {
+    override def mmbwmon(node: Node): IO[Double] = for {
         measured <- makeRequest(node.uri, MmbwmonEndpoints.measure)(())
     } yield 3 * (1 - measured) / 2
 

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/system/LoggingSchedulingSystem.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/system/LoggingSchedulingSystem.scala
@@ -3,16 +3,13 @@ import cats.effect.IO
 import cats.implicits._
 import ru.skelantros.coscheduler.image.ImageArchive
 import ru.skelantros.coscheduler.logging.{DefaultLogger, Logger}
-import ru.skelantros.coscheduler.main.system.SchedulingSystem.TaskLogs
 import ru.skelantros.coscheduler.main.system.WithTaskSpeedEstimate.TaskSpeed
 import ru.skelantros.coscheduler.model.{CpuSet, Node, Task}
 import sttp.model.Uri
 
 import scala.concurrent.duration.FiniteDuration
 
-trait LoggingSchedulingSystem extends SchedulingSystem with WithRamBenchmark with WithTaskSpeedEstimate with DefaultLogger {
-
-    def loggerConfig: Logger.Config
+trait LoggingSchedulingSystem extends SchedulingSystem with WithMmbwmon with WithTaskSpeedEstimate with DefaultLogger {
 
     abstract override def nodeInfo(uri: Uri): IO[Node] =
         super.nodeInfo(uri) <* log.debug("")(s"nodeInfo($uri)")
@@ -38,13 +35,13 @@ trait LoggingSchedulingSystem extends SchedulingSystem with WithRamBenchmark wit
     abstract override def waitForTask(task: Task.Created): IO[Boolean] =
         super.waitForTask(task) <* log.debug("")(s"waitForTask($task)")
 
-    abstract override def ramBenchmark(node: Node): IO[Double] = for {
-        result <- super.ramBenchmark(node)
+    abstract override def mmbwmon(node: Node): IO[Double] = for {
+        result <- super.mmbwmon(node)
         _ <- log.debug("")(s"ramBenchmark($node) = $result")
     } yield result
 
-    override def avgRamBenchmark(node: Node)(attempts: Int): IO[Double] = for {
-        result <- super.avgRamBenchmark(node)(attempts)
+    override def avgMmbwmon(node: Node)(attempts: Int): IO[Double] = for {
+        result <- super.avgMmbwmon(node)(attempts)
         _ <- log.debug("")(s"avgRamBenchmark($node) = $result")
     } yield result
 

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/system/WithMmbwmon.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/system/WithMmbwmon.scala
@@ -4,13 +4,13 @@ import cats.effect.IO
 import ru.skelantros.coscheduler.model.Node
 import cats.implicits._
 
-trait WithRamBenchmark { this: SchedulingSystem =>
-    def ramBenchmark(node: Node): IO[Double]
+trait WithMmbwmon { this: SchedulingSystem =>
+    def mmbwmon(node: Node): IO[Double]
 
     private val avg: Iterable[Double] => Double = ns => ns.sum / ns.size
 
     // TODO не очень эффективно с точки зрения арифметики чисел с плавающей точки
     // TODO parSequence запускает запросы параллельно, но mmbwmon всё равно обрабатывает их последовательно, можно заменить на sequence
-    def avgRamBenchmark(node: Node)(attempts: Int): IO[Double] =
-        (1 to attempts).map(_ => ramBenchmark(node)).toList.parSequence.map(avg)
+    def avgMmbwmon(node: Node)(attempts: Int): IO[Double] =
+        (1 to attempts).map(_ => mmbwmon(node)).toList.parSequence.map(avg)
 }

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/utils/SemaphoreResource.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/utils/SemaphoreResource.scala
@@ -1,0 +1,26 @@
+package ru.skelantros.coscheduler.main.utils
+
+import cats.Applicative
+import cats.effect.GenConcurrent
+import cats.effect.std.Semaphore
+import cats.implicits._
+
+case class SemaphoreResource[A, F[_]](x: A, semaphore: Semaphore[F])(implicit conc: GenConcurrent[F, _]) {
+    def getAndComputeF[B](f: A => F[B]): F[B] = for {
+        _ <- semaphore.acquire
+        action <- f(x)
+        _ <- semaphore.release
+    } yield action
+
+    def getAndCompute[B](f: A => B): F[B] = getAndComputeF(f andThen Applicative[F].pure)
+}
+
+object SemaphoreResource {
+    class Partial[F[_]](implicit conc: GenConcurrent[F, _]) {
+        def from[A](x: A, availability: Int): F[SemaphoreResource[A, F]] = for {
+            semaphore <- Semaphore[F](availability)
+        } yield SemaphoreResource(x, semaphore)
+    }
+
+    def apply[F[_]](implicit conc: GenConcurrent[F, _]): Partial[F] = new Partial
+}

--- a/worker-module/src/main/scala/ru/skelantros/coscheduler/worker/server/WorkerServerLogic.scala
+++ b/worker-module/src/main/scala/ru/skelantros/coscheduler/worker/server/WorkerServerLogic.scala
@@ -169,7 +169,7 @@ class WorkerServerLogic(configuration: WorkerConfiguration, sessionCtxRef: Ref[I
 
     private def measureTaskSpeed(task: Task.Created, attempts: Int, duration: FiniteDuration): IO[ServerResponse[Double]] = for {
         resultOpts <- (0 until attempts).map(_ => TaskSpeedMeasurer(duration)(task)).toVector.sequence
-        resultOpt = resultOpts.foldLeft(Option.empty[Double])(sumOpts).map(_ / attempts)
+        resultOpt = resultOpts.foldLeft(Option(0d))(sumOpts).map(_ / attempts)
         result = resultOpt.fold(
             ServerResponse.badRequest[Double](s"Incorrect task speed measurement result for task ${task.id}.")
         )(ServerResponse(_))


### PR DESCRIPTION
This strategy works a bit better on one node with tasks `LU-C`, `BT-C`, `EP-D`, `EP-D` (388 sec vs 391 for sequential). Important factors are:
- BW strategy reserves one core for benchmarking.
- The only compatible tasks in this sequence are `EP-D`s.