### PR TITLE
Updated BW Alt -> master

### DIFF
--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/implicits.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/implicits.scala
@@ -23,4 +23,8 @@ object implicits {
             end <- Clock[F].monotonic
         } yield (result, end - start)
     }
+
+    implicit class SumByOps[A](xs: Iterable[A]) {
+        def sumBy[B](f: A => B)(implicit num: Numeric[B]): B = xs.foldLeft(num.zero)((acc, x) => num.plus(acc, f(x)))
+    }
 }

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/strategy/MemoryBWAltStrategy.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/strategy/MemoryBWAltStrategy.scala
@@ -10,7 +10,7 @@ import ru.skelantros.coscheduler.main.system.{SchedulingSystem, WithMmbwmon}
 import ru.skelantros.coscheduler.main.utils.SemaphoreResource
 import ru.skelantros.coscheduler.model.{CpuSet, Node, Task}
 
-import scala.collection.immutable.TreeSet
+import scala.annotation.tailrec
 import scala.concurrent.duration.DurationInt
 
 class MemoryBWAltStrategy(val schedulingSystem: SchedulingSystem with WithMmbwmon, val config: Configuration) extends Strategy {
@@ -46,57 +46,128 @@ class MemoryBWAltStrategy(val schedulingSystem: SchedulingSystem with WithMmbwmo
         _ <- log.debug(node.id)(s"${createdTask.title}: $benchmarkResult")
     } yield NodeTask(sTask, benchmarkResult, pausedTask)
 
-    private class WorkerNode(node: Node, nodeTasks: TreeSet[NodeTask], sharedTasks: Ref[IO, SharedTasks], bwAndWaiting: SemaphoreResource[(Ref[IO, Double], Ref[IO, Boolean]), IO]) {
+    private class WorkerNode(node: Node, nodeTasks: List[NodeTask], sharedTasks: Ref[IO, SharedTasks], bwAndWaiting: SemaphoreResource[(Ref[IO, Double], Ref[IO, Boolean]), IO]) {
         def execute: IO[Set[Task.Created]] = go(nodeTasks, Set.empty)
 
-        private def go(nodeTasks: TreeSet[NodeTask], tasks: Set[Task.Created]): IO[Set[Task.Created]] = for {
-            findTaskRes <- findTask(nodeTasks)
-            action <- findTaskRes match {
-                case TaskFound(task) =>
-                    schedulingSystem.saveResumeTask(task.task) >> runTaskCallback(task) >> go(nodeTasks - task, tasks + task.task)
-                case NoMoreTasks => tasks.pure[IO]
-                case NotFound => go(nodeTasks, tasks).delayBy(delay)
+//        private def go(nodeTasks: TreeSet[NodeTask], tasks: Set[Task.Created]): IO[Set[Task.Created]] = for {
+//            findTaskRes <- findTask(nodeTasks)
+//            action <- findTaskRes match {
+//                case TaskFound(task) =>
+//                    schedulingSystem.saveResumeTask(task.task) >> runTaskCallback(task) >> go(nodeTasks - task, tasks + task.task)
+//                case NoMoreTasks => tasks.pure[IO]
+//                case NotFound => go(nodeTasks, tasks).delayBy(delay)
+//            }
+//        } yield action
+
+        private def go(nodeTasks: List[NodeTask], tasks: Set[Task.Created]): IO[Set[Task.Created]] = for {
+            findTasksRes <- findTasks(nodeTasks)
+            action <- findTasksRes match {
+                case TasksFound(foundTasks, updatedNodeTasks) =>
+                    foundTasks.parMap(t => schedulingSystem.saveResumeTask(t.task)) >>
+                    runTasksCallback(foundTasks) >>
+                    go(updatedNodeTasks, foundTasks.foldLeft(tasks)(_ + _.task))
+                case NoMoreTasks(foundTasks) =>
+                    foundTasks.parMap(t => schedulingSystem.saveResumeTask(t.task)) >>
+                    runTasksCallback(foundTasks) >>
+                    foundTasks.foldLeft(tasks)(_ + _.task).pure[IO]
+                case TasksNotFound => go(nodeTasks, tasks).delayBy(delay)
             }
         } yield action
 
-        private def findTask(nodeTasks: TreeSet[NodeTask]): IO[FindTaskResult] = bwAndWaiting.getAndComputeF { case (bwRef, waitingRef) =>
+        private def findTasks(nodeTasks: List[NodeTask]): IO[FindTasksResult] = bwAndWaiting.getAndComputeF { case (bwRef, waitingRef) =>
             for {
                 bw <- bwRef.get
                 waiting <- waitingRef.get
                 result <-
-                    if (waiting) NotFound.pure[IO]
+                    if(waiting) TasksNotFound.pure[IO]
                     else sharedTasks.modify { sts =>
-                        if (sts.isEmpty) (sts, IO.pure(NoMoreTasks))
-                        else nodeTasks.find(nt => sts(nt.sTask)) match {
-                            case Some(nodeTask) if bw == 0 || bw + nodeTask.speed <= threshold =>
-                                (sts - nodeTask.sTask, IO.pure(TaskFound(nodeTask)))
-                            case _ =>
-                                (sts, IO.pure(NotFound) <* waitingRef.set(true))
+                        suitableTasks(nodeTasks, sts, bw) match {
+                            case (chosenTasks, Some(updatedNodeTasks)) =>
+                                (chosenTasks.foldLeft(sts)(_ - _.sTask), waitingRef.set(true) >> TasksFound(chosenTasks, updatedNodeTasks).pure[IO])
+                            case (chosenTasks, None) =>
+                                // т.к. всегда sts in nodeTasks, то этот кейс возможен т. и т., когда задач больше не осталось
+                                (Set.empty, NoMoreTasks(chosenTasks).pure[IO])
                         }
                     }.flatten
             } yield result
         }
 
-        private def runTaskCallback(task: NodeTask): IO[Unit] = {
+        /**
+         * первый элемент кортежа (список выбранных задач) отсортирован в обратном порядке, второй - просто отсортирован
+         */
+        @tailrec
+        private def suitableTasks(nodeTasks: List[NodeTask], sts: SharedTasks, bw: Double, cur: List[NodeTask] = List.empty): (List[NodeTask], Option[List[NodeTask]]) = nodeTasks match {
+            case t :: ts if !sts(t.sTask) => suitableTasks(ts, sts, bw, cur)
+            case t :: ts if bw == 0 || t.speed + bw <= threshold => suitableTasks(ts, sts, bw + t.speed, t :: cur)
+            case _ :: _ => (cur, Some(nodeTasks))
+            case Nil => (cur, None)
+        }
+
+        private def runTasksCallback(nodeTasks: List[NodeTask]): IO[Unit] = {
+            lazy val tasksTotalBw = nodeTasks.sumBy(_.speed)
+
             val callbackStart = bwAndWaiting.getAndComputeF { case (bwRef, _) =>
                 for {
-                    _ <- bwRef.update(_ + task.speed)
+                    _ <- bwRef.update(_ + tasksTotalBw)
                     totalBw <- bwRef.get
-                    _ <- log.debug(node.id)(s"Task $task has been started. totalBw = $totalBw")
+                    _ <- log.debug(node.id)(s"Tasks ${nodeTasks.map(_.task.title).mkString(",")} have been started. totalBw = $totalBw")
                 } yield ()
             }
 
-            val callbackEnd = bwAndWaiting.getAndComputeF { case (bwRef, waitingRef) =>
-                for {
-                    _ <- bwRef.update(_ - task.speed)
-                    _ <- waitingRef.set(false)
-                    totalBw <- bwRef.get
-                    _ <- log.debug(node.id)(s"Task $task has been completed. totalBw = $totalBw")
-                } yield ()
-            }
+            val singleCallbackEnd = (task: NodeTask) =>
+                schedulingSystem.waitForTask(task.task) >>
+                bwAndWaiting.getAndComputeF { case (bwRef, waitingRef) =>
+                    for {
+                        _ <- bwRef.update(_ - task.speed)
+                        _ <- waitingRef.set(false)
+                        totalBw <- bwRef.get
+                        _ <- log.debug(node.id)(s"Task ${task.task.title} has been completed. totalBw = $totalBw")
+                    } yield ()
+                }
 
-            callbackStart >> (schedulingSystem.waitForTask(task.task) >> callbackEnd).start >> IO.unit
+            val callbacksEnd = nodeTasks.parMap(singleCallbackEnd(_).start)
+
+            callbackStart >> callbacksEnd >> IO.unit
         }
+
+//        private def findTask(nodeTasks: TreeSet[NodeTask]): IO[FindTaskResult] = bwAndWaiting.getAndComputeF { case (bwRef, waitingRef) =>
+//            for {
+//                bw <- bwRef.get
+//                waiting <- waitingRef.get
+//                result <-
+//                    if (waiting) NotFound.pure[IO]
+//                    else sharedTasks.modify { sts =>
+//                        if (sts.isEmpty) (sts, IO.pure(NoMoreTasks))
+//                        else nodeTasks.find(nt => sts(nt.sTask)) match {
+//                            case Some(nodeTask) if bw == 0 || bw + nodeTask.speed <= threshold =>
+//                                (sts - nodeTask.sTask, IO.pure(TaskFound(nodeTask)))
+//                            case _ =>
+//                                (sts, IO.pure(NotFound) <* waitingRef.set(true))
+//                        }
+//                    }.flatten
+//            } yield result
+//        }
+
+//        private def runTaskCallback(task: NodeTask): IO[Unit] = {
+//            val callbackStart = bwAndWaiting.getAndComputeF { case (bwRef, _) =>
+//                for {
+//                    _ <- bwRef.update(_ + task.speed)
+//                    totalBw <- bwRef.get
+//                    _ <- log.debug(node.id)(s"Task $task has been started. totalBw = $totalBw")
+//                } yield ()
+//            }
+//
+//            val callbackEnd = bwAndWaiting.getAndComputeF { case (bwRef, waitingRef) =>
+//                for {
+//                    _ <- bwRef.update(_ - task.speed)
+//                    _ <- waitingRef.set(false)
+//                    totalBw <- bwRef.get
+//                    _ <- log.debug(node.id)(s"Task $task has been completed. totalBw = $totalBw")
+//                } yield ()
+//            }
+//
+//            callbackStart >> (schedulingSystem.waitForTask(task.task) >> callbackEnd).start >> IO.unit
+//        }
     }
 
     private object WorkerNode {
@@ -104,7 +175,7 @@ class MemoryBWAltStrategy(val schedulingSystem: SchedulingSystem with WithMmbwmo
             bwRef <- Ref.of[IO, Double](0d)
             waitingRef <- Ref.of[IO, Boolean](false)
             resource <- SemaphoreResource[IO].from((bwRef, waitingRef), 1)
-        } yield new WorkerNode(node, NodeTask.setFrom(nodeTasks), sharedTasks, resource)
+        } yield new WorkerNode(node, nodeTasks.toList.sorted, sharedTasks, resource)
     }
 }
 
@@ -115,14 +186,13 @@ object MemoryBWAltStrategy {
     private type SharedTasks = Set[StrategyTask]
 }
 
-private sealed trait FindTaskResult
-private case class TaskFound(task: NodeTask) extends FindTaskResult
-private case object NoMoreTasks extends FindTaskResult
-private case object NotFound extends FindTaskResult
+private sealed trait FindTasksResult extends Product
+private case class TasksFound(tasksToStart: List[NodeTask], updatedNodeTasks: List[NodeTask]) extends FindTasksResult
+private case class NoMoreTasks(tasks: List[NodeTask]) extends FindTasksResult
+private case object TasksNotFound extends FindTasksResult
 
 private case class NodeTask(sTask: StrategyTask, speed: Double, task: Task.Created)
 
 private object NodeTask {
-    private val ordering = Ordering.by[NodeTask, Double](_.speed)
-    def setFrom(coll: Iterable[NodeTask]): TreeSet[NodeTask] = TreeSet.from(coll)(ordering)
+    implicit val ordering: Ordering[NodeTask] = Ordering.by[NodeTask, Double](_.speed)
 }

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/system/HttpSchedulingSystem.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/system/HttpSchedulingSystem.scala
@@ -71,6 +71,10 @@ class HttpSchedulingSystem(val config: Configuration)
     override def isRunning(task: Task.Created): IO[Boolean] =
         makeRequest(task.node.uri, WorkerEndpoints.isRunning)(task)
 
+
+    override def updateCpus(task: Task.Created, cpuSet: CpuSet): IO[Task.Created] =
+        makeRequest(task.node.uri, WorkerEndpoints.updateCpus)(task, Some(cpuSet))
+
     // 1 - (measured - 0.33) / (1 - 0.33) = 1 + 0.33/0.67 - measured/0.67 = 1 / 0.67 - measured / 0.67 ~=~ 3/2 - 3/2 * measured = 3/2 (1 - measured)
     override def mmbwmon(node: Node): IO[Double] = for {
         measured <- makeRequest(node.uri, MmbwmonEndpoints.measure)(())

--- a/main-module/src/main/scala/ru/skelantros/coscheduler/main/system/SchedulingSystem.scala
+++ b/main-module/src/main/scala/ru/skelantros/coscheduler/main/system/SchedulingSystem.scala
@@ -44,4 +44,6 @@ trait SchedulingSystem {
     def isRunning(task: Task.Created): IO[Boolean]
 
     def initSession(sessionCtx: SessionContext)(node: Node): IO[Unit]
+
+    def updateCpus(task: Task.Created, cpuSet: CpuSet): IO[Task.Created]
 }

--- a/models/src/main/scala/ru/skelantros/coscheduler/model/CpuSet.scala
+++ b/models/src/main/scala/ru/skelantros/coscheduler/model/CpuSet.scala
@@ -14,7 +14,7 @@ object CpuSet {
         case regex(start, end) =>
             (start.toIntOption zip end.toIntOption).flatMap { case (start, end) =>
                 val count = end - start + 1
-                if(count > 0 && start > 0) Some(CpuSet(start, count))
+                if(count > 0 && start >= 0) Some(CpuSet(start, count))
                 else None
             }
         case _ => None

--- a/models/src/main/scala/ru/skelantros/coscheduler/model/CpuSet.scala
+++ b/models/src/main/scala/ru/skelantros/coscheduler/model/CpuSet.scala
@@ -26,6 +26,6 @@ object CpuSet {
     implicit val decoder: Decoder[CpuSet] =
         Decoder.decodeString.emap(CpuSet(_).toRight("wrong value"))
 
-    implicit val queryCodec: tapir.Codec[List[String], Option[CpuSet], TextPlain] =
+    implicit val optQueryCodec: tapir.Codec[List[String], Option[CpuSet], TextPlain] =
         tapir.Codec.list[String, String, TextPlain].map(_.headOption.flatMap(CpuSet(_)))(_.map(_.asString).toList)
 }

--- a/models/src/main/scala/ru/skelantros/coscheduler/worker/endpoints/WorkerEndpoints.scala
+++ b/models/src/main/scala/ru/skelantros/coscheduler/worker/endpoints/WorkerEndpoints.scala
@@ -53,4 +53,7 @@ object WorkerEndpoints {
         .in(query[Int]("attempts").default(1))
         .in(query[FiniteDuration]("durationMs"))
         .out(jsonBody[Double])
+
+    // todo in(CpuSet)
+    final val updateCpus = taskEndpoint.in("update-cpus").in(query[Option[CpuSet]]("cpus"))
 }


### PR DESCRIPTION
- Nodes are now choosing tasks in batches (as long as bw < threshold) instead of one by one. This makes less acquires of a SharedTasks ref as well as fixes some scheduling bad cases.
- Tasks containers' `cpuset-cpus` parameter is updated after initial benchmarking, so tasks utilize all cores of each node. In previous version a single core on each node was reserved for benchmarking.

This results in a slightly better performance on a single node, but this strategy still goes badly on two unequal nodes (438 vs 380 seconds on a compatible tasks sample). 